### PR TITLE
Update all configs to enable instant resupply and goal heal

### DIFF
--- a/cfg/pt_cup.cfg
+++ b/cfg/pt_cup.cfg
@@ -12,7 +12,8 @@ mp_timelimit                 "0"    // unsets server timelimit
 mp_windifference             "0"    // unsets windifference
 mp_maxrounds                 "0"    // unsets maxrounds
 
-sm_pt_allow_instant_resupply 0      // disable instant resupply option of sm_pt_resupply; experimental feature
+sm_pt_allow_instant_resupply 1      // enable instant resupply command from pass time plugin which is not dependent on item servers
+sm_pt_goal_heal 4                   // set healing value for goal heal
 
 mp_tournament_whitelist "cfg/pt_pug_whitelist.txt" // our WL will usually be more updated than RGLs
 

--- a/cfg/pt_global_official.cfg
+++ b/cfg/pt_global_official.cfg
@@ -13,7 +13,8 @@ mp_timelimit                 "0"    // unsets server timelimit
 mp_windifference             "0"    // unsets windifference
 mp_maxrounds                 "0"    // unsets maxrounds
 
-sm_pt_allow_instant_resupply 0      // disable instant resupply option of sm_pt_resupply; experimental feature
+sm_pt_allow_instant_resupply 1      // enable instant resupply command from pass time plugin which is not dependent on item servers
+sm_pt_goal_heal 4                   // set healing value for goal heal
 
 mp_tournament_whitelist "cfg/pt_pug_whitelist.txt" // our WL will usually be more updated than RGLs
 

--- a/cfg/pt_global_pug.cfg
+++ b/cfg/pt_global_pug.cfg
@@ -15,7 +15,8 @@ mp_maxrounds                 "0"    // unsets maxrounds
 tf_christmas_ball_chance     "0"    // removes christmas ball
 sv_pausable                  "0"    // no pauses for pugs
 
-sm_pt_allow_instant_resupply 1      // enable instant resupply option of sm_pt_resupply; experimental feature
+sm_pt_allow_instant_resupply 1      // enable instant resupply command from pass time plugin which is not dependent on item servers
+sm_pt_goal_heal 4                   // set healing value for goal heal
 
 mp_tournament_whitelist "cfg/pt_pug_whitelist.txt" // our WL will usually be more updated than RGLs
 


### PR DESCRIPTION
Updated pt_global_pug, pt_global_official and pt_cup to include the following commands:

sm_pt_allow_instant_resupply 1 - Enables the instant resupply feature
sm_pt_goal_heal 4 - Enables goal heal with 4 hp per 0.5 seconds