### PR TITLE
Add lockon info to pass_free event logs

### DIFF
--- a/scripting/p4sstime.sp
+++ b/scripting/p4sstime.sp
@@ -855,15 +855,27 @@ Action Event_PassFree(Event event, const char[] name, bool dontBroadcast)
     GetEntPropVector(eiJack, Prop_Data, "m_vecAbsOrigin", fFreeBallPos);
     GetEntPropVector(owner, Prop_Data, "m_vecAbsVelocity", fFreeBallThrowerVec);
     eiPassTarget = EntRefToEntIndex(GetEntPropEnt(owner, Prop_Send, "m_hPasstimePassTarget"));
+    if (eiPassTarget != -1) // ball was thrown with lock-on
+    {
+        SetLogInfo(owner, eiPassTarget);
+        LogToGame("\"%N<%i><%s><%s>\" triggered \"pass_free\" to \"%N<%i><%s><%s>\" (has_lock \"1\") (thrower_position \"%.0f %.0f %.0f\") (target_position \"%.0f %.0f %.0f\")",
+                  user1, GetClientUserId(user1), user1steamid, user1team,
+                  user2, GetClientUserId(user2), user2steamid, user2team,
+                  user1position[0], user1position[1], user1position[2],
+                  user2position[0], user2position[1], user2position[2]);
+    }
+    else    // ball was thrown loose
+    {
+        SetLogInfo(owner);
+        LogToGame("\"%N<%i><%s><%s>\" triggered \"pass_free\" (has_lock \"0\") (thrower_position \"%.0f %.0f %.0f\")",
+                  user1, GetClientUserId(user1), user1steamid, user1team,
+                  user1position[0], user1position[1], user1position[2]);
+    }
     if (!(arrbBlastJumpStatus[owner]))
     {
         arrbPanaceaCheck[owner]  = false;
         arrbWinStratCheck[owner] = false;
     }
-    SetLogInfo(owner);
-    LogToGame("\"%N<%i><%s><%s>\" triggered \"pass_free\" (position \"%.0f %.0f %.0f\")",
-              user1, GetClientUserId(user1), user1steamid, user1team,
-              user1position[0], user1position[1], user1position[2]);
     return Plugin_Handled;
 }
 


### PR DESCRIPTION
Changes pass_free logs to specify whether the throw was locked on to another player (has_lock), and if so include that player's info (username, user index, steamid, team). This also changes `position` to `thrower_position`, which is more consistent with other events.

Current log info:
(Lock or no-lock)
`"Masonator<2><[U:1:449416302]><Red>" triggered "pass_free" (position "171 981 -909")`

New log info:
(Lock)
`"Masonator<2><[U:1:449416302]><Red>" triggered "pass_free" to "Bot01<3><BOT><Red>" (has_lock "1") (thrower_position "-702 836 -2047") (target_position "-444 344 -2047")`
(No lock)
`"Masonator<2><[U:1:449416302]><Red>" triggered "pass_free" (has_lock "0") (thrower_position "114 -912 -2016")`