### PR TITLE
fix regressions caused by v3.0.1

### DIFF
--- a/scripting/p4sstime.sp
+++ b/scripting/p4sstime.sp
@@ -13,7 +13,7 @@
 #pragma semicolon 1 // required for logs.tf
 #pragma newdecls required
 
-#define VERSION "3.0.1"
+#define VERSION "3.0.2"
 
 // Macros
 #define GD      GameData 

--- a/scripting/p4sstime.sp
+++ b/scripting/p4sstime.sp
@@ -887,7 +887,7 @@ public void OnMapEnd() {
 }
 
 public void OnGameFrame() {
-  if (bBallLoose) {
+  if (bBallLoose && IsValidJackEntity()) {
     TFTeam ballTeam = GetBallTeam();
     if (ballTeam != eLastTickBallTeam) {
       VerboseLog("Ball team changed from %d (%s) to %d (%s)", eLastTickBallTeam, TFTeamToString(eLastTickBallTeam), ballTeam, TFTeamToString(ballTeam));
@@ -1529,8 +1529,15 @@ void FormatPlayerNameWithTeam(int player, char[] outputString) {
 // 1: spectator
 // 2: TF_TEAM_RED
 // 3: TF_TEAM_BLU
+bool IsValidJackEntity() {
+  if (entJack == 0 || !IsValidEntity(entJack)) return false;
+  char classname[32];
+  GetEntityClassname(entJack, classname, sizeof(classname));
+  return StrEqual(classname, "passtime_ball");
+}
+
 stock TFTeam GetBallTeam() {
-  if (entJack == 0 || !IsValidEntity(entJack)) {
+  if (!IsValidJackEntity()) {
     LogStackTrace("Ball entity invalid, returning Unassigned");
     return TFTeam_Unassigned;
   }

--- a/scripting/p4sstime/convars.sp
+++ b/scripting/p4sstime/convars.sp
@@ -218,11 +218,20 @@ void RemoveStocks(int client) {
   }
 }
 
+// check to see if the timer entity is still valid
+// seems like IsValidEntity() is not enough because a different can use the same index
+bool IsValidTimerEntity() {
+  if (g_iCachedTimerEntity == -1 || !IsValidEntity(g_iCachedTimerEntity)) return false;
+  char classname[32];
+  GetEntityClassname(g_iCachedTimerEntity, classname, sizeof(classname));
+  return StrEqual(classname, "team_round_timer");
+}
+
 // Validate entity cache and rebuild if any cached entity has become invalid
 void ValidateEntityCache() {
   bool needsRebuild = false;
 
-  if (g_iCachedTimerEntity != -1 && !IsValidEntity(g_iCachedTimerEntity))
+  if (g_iCachedTimerEntity != -1 && !IsValidTimerEntity())
     needsRebuild = true;
 
   if (!needsRebuild) {

--- a/scripting/p4sstime/pass_menu.sp
+++ b/scripting/p4sstime/pass_menu.sp
@@ -17,7 +17,7 @@ public OnClientCookiesCached(int client) {
   GET_BOOL_COOKIE(ck_bLegacyColors, arr_iClientPrefs[client].bLegacyColors, false)
   GET_BOOL_COOKIE(ck_bAirshotLog, arr_iClientPrefs[client].bAirshotLog, false)
   GetSpecFOVCookie(client);
-  if (TF2_GetClientTeam(client) == TFTeam_Spectator) ApplySpecFov(client);
+  if (IsClientInGame(client) && TF2_GetClientTeam(client) == TFTeam_Spectator) ApplySpecFov(client);
 }
 
 Action CMenu(int client, int args) {

--- a/scripting/p4sstime/warmup.sp
+++ b/scripting/p4sstime/warmup.sp
@@ -11,7 +11,6 @@ enum GameState {
 };
 
 GameState g_iGameState       = STATE_WAITING;
-bool      g_bRoundStartPending = false;
 
 Action EGameState_RoundRestartSeconds(Event event, const char[] name, bool dontBroadcast) {
   g_iGameState = STATE_COUNTDOWN;
@@ -20,7 +19,6 @@ Action EGameState_RoundRestartSeconds(Event event, const char[] name, bool dontB
 
 Action EGameState_RestartRound(Event event, const char[] name, bool dontBroadcast) {
   g_iGameState = STATE_GAME_START;
-  g_bRoundStartPending = false;
   return Plugin_Continue;
 }
 
@@ -31,7 +29,6 @@ Action EGameState_MapTimeRemaining(Event event, const char[] name, bool dontBroa
 
 Action EGameState_RoundStart(Event event, const char[] name, bool dontBroadcast) {
   g_iGameState = STATE_GAME_START;
-  g_bRoundStartPending = true;
   return Plugin_Continue;
 }
 
@@ -45,43 +42,31 @@ void SetGameState(GameState state) {
 }
 
 void OnGameStateRoundActive() {
-  if (g_bRoundStartPending) {
-    g_iGameState = STATE_ROUND_ACTIVE;
-    g_bRoundStartPending = false;
-  } else if (g_iGameState == STATE_ROUND_FINISHED) {
-    // Game ended directly from a round win
-    g_iGameState = STATE_GAME_FINISHED;
-  } else {
-    // round_active without a matching round_start - treat as game end
-    g_iGameState = STATE_GAME_FINISHED;
-  }
+  g_iGameState = STATE_ROUND_ACTIVE;
 }
 
 void OnGameStateRoundWin() {
   g_iGameState = STATE_ROUND_FINISHED;
-  g_bRoundStartPending = false;
 }
 
 bool IsMatch() {
+  if (g_iGameState != STATE_WAITING) {
+    return g_iGameState == STATE_GAME_START
+        || g_iGameState == STATE_ROUND_ACTIVE
+        || g_iGameState == STATE_ROUND_FINISHED;
+  }
+
   bool awaitingReadyRestart = view_as<bool>(GameRules_GetProp("m_bAwaitingReadyRestart"));
   bool timerPaused          = false;
   bool timerDisabled        = false;
   bool isPostRound          = GameRules_GetRoundState() == RoundState_TeamWin;
 
-  if (g_iCachedTimerEntity != -1 && IsValidEntity(g_iCachedTimerEntity)) {
+  if (IsValidTimerEntity()) {
     timerPaused   = view_as<bool>(GetEntProp(g_iCachedTimerEntity, Prop_Send, "m_bTimerPaused"));
     timerDisabled = view_as<bool>(GetEntProp(g_iCachedTimerEntity, Prop_Send, "m_bIsDisabled"));
   }
 
-  bool activeByTimer = !(awaitingReadyRestart || timerPaused || timerDisabled || isPostRound);
-
-  bool activeByState = g_iGameState == STATE_GAME_START
-                    || g_iGameState == STATE_ROUND_ACTIVE
-                    || g_iGameState == STATE_ROUND_FINISHED;
-
-  // State machine is primary, but the timer/gamerules check keeps the plugin
-  // from reporting the wrong state on a fresh load before any events arrive.
-  return activeByState || activeByTimer;
+  return !(awaitingReadyRestart || timerPaused || timerDisabled || isPostRound);
 }
 
 void SetAmmo(int client, int weapon, int ammo) {


### PR DESCRIPTION
These changes should fix the two exceptions being spammed in console

```
L 08/03/2026 - 21:41:55: [SM] Exception reported: Client 1 is not in game
L 08/03/2026 - 21:41:55: [SM] Blaming: p4sstime.smx
L 08/03/2026 - 21:41:55: [SM] Call stack trace:
L 08/03/2026 - 21:41:55: [SM]   [0] GetClientTeam
L 08/03/2026 - 21:41:55: [SM]   [1] Line 362, /scripting/include/tf2_stocks.inc::TF2_GetClientTeam
L 08/03/2026 - 21:41:55: [SM]   [2] Line 20, p4sstime/pass_menu.sp::OnClientCookiesCached
```

```
L 08/03/2026 - 21:43:02: [SM] Exception reported: Property "m_bTimerPaused" not found (entity 88/func_brush)
L 08/03/2026 - 21:43:02: [SM] Blaming: p4sstime.smx
L 08/03/2026 - 21:43:02: [SM] Call stack trace:
L 08/03/2026 - 21:43:02: [SM]   [0] GetEntProp
L 08/03/2026 - 21:43:02: [SM]   [1] Line 72, p4sstime/warmup.sp::IsMatch
L 08/03/2026 - 21:43:02: [SM]   [2] Line 934, p4sstime.sp::OnGameFrame
```

This PR also changes how the warmup logic checks to be more consistent.

One thing to note, ConVar names were changed with 3.0.1 (primarily goalheal and demoresist), this means all existing RGL configs do not function as intended and need to be fixed.